### PR TITLE
Update carto_file_module.c

### DIFF
--- a/opal/mca/carto/file/carto_file_module.c
+++ b/opal/mca/carto/file/carto_file_module.c
@@ -146,9 +146,9 @@ static int opal_carto_file_parse(const char *cartofile)
         "Integer",
         "Name",
         "Node connection",
-        "Undefined"
-        "Undefined"
-        "Undefined"
+        "Undefined",
+        "Undefined",
+        "Undefined",
     };
 
     /* set the done flag to false. at the end of file the the lexical analyzer will set it to true */


### PR DESCRIPTION
This was found by new clang-tidy checker.
'misc-suspicious-missing-comma'
